### PR TITLE
added checks for apikey and project id env variables

### DIFF
--- a/src/Poeditor/Poeditor.php
+++ b/src/Poeditor/Poeditor.php
@@ -3,6 +3,7 @@
 namespace NextApps\PoeditorSync\Poeditor;
 
 use GuzzleHttp\Client;
+use InvalidArgumentException;
 
 class Poeditor
 {
@@ -32,6 +33,15 @@ class Poeditor
      */
     public function __construct(Client $client, string $apiKey, string $projectId)
     {
+        if (!is_string($apiKey) || !$apiKey) {
+            throw new InvalidArgumentException('Invalid API key');
+        }
+
+        if (!is_string($projectId) || !$projectId) {
+            throw new InvalidArgumentException('Invalid project id');
+        }
+
+
         $this->client = $client;
         $this->apiKey = $apiKey;
         $this->projectId = $projectId;

--- a/src/Poeditor/Poeditor.php
+++ b/src/Poeditor/Poeditor.php
@@ -31,7 +31,7 @@ class Poeditor
      *
      * @return void
      */
-    public function __construct(Client $client, string $apiKey, string $projectId)
+    public function __construct(Client $client, $apiKey, $projectId)
     {
         if (! is_string($apiKey) || ! $apiKey) {
             throw new InvalidArgumentException('Invalid API key');

--- a/tests/PoeditorTest.php
+++ b/tests/PoeditorTest.php
@@ -83,10 +83,18 @@ class PoeditorTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_error_if_config_values_are_empty()
+    public function it_throws_an_error_if_api_key_is_empty()
     {
         $this->expectException(InvalidArgumentException::class);
         config()->set('poeditor-sync.api_key', '');
+
+        app(Poeditor::class)->download($this->faker->locale);
+    }
+
+    /** @test */
+    public function it_throws_an_error_if_project_id_is_empty()
+    {
+        $this->expectException(InvalidArgumentException::class);
         config()->set('poeditor-sync.project_id', '');
 
         app(Poeditor::class)->download($this->faker->locale);

--- a/tests/PoeditorTest.php
+++ b/tests/PoeditorTest.php
@@ -3,10 +3,11 @@
 namespace NextApps\PoeditorSync\Tests;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use GuzzleHttp\Handler\MockHandler;
 use NextApps\PoeditorSync\Poeditor\Poeditor;
 use NextApps\PoeditorSync\Poeditor\UploadResponse;
 
@@ -80,6 +81,17 @@ class PoeditorTest extends TestCase
         $this->assertEquals(parse_url($url, PHP_URL_HOST), $downloadExportRequest->getUri()->getHost());
         $this->assertEquals(parse_url($url, PHP_URL_PATH), $downloadExportRequest->getUri()->getPath());
     }
+
+    /** @test */
+    public function it_throws_an_error_if_config_values_are_empty()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        config()->set('poeditor-sync.api_key', '');
+        config()->set('poeditor-sync.project_id', '');
+
+        app(Poeditor::class)->download($this->faker->locale);
+    }
+
 
     /** @test */
     public function it_uploads_translations()

--- a/tests/PoeditorTest.php
+++ b/tests/PoeditorTest.php
@@ -86,7 +86,18 @@ class PoeditorTest extends TestCase
     public function it_throws_an_error_if_api_key_is_empty()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid API key');
         config()->set('poeditor-sync.api_key', '');
+
+        app(Poeditor::class)->download($this->faker->locale);
+    }
+
+    /** @test */
+    public function it_throws_an_error_if_api_key_is_null()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid API key');
+        config()->set('poeditor-sync.api_key', null);
 
         app(Poeditor::class)->download($this->faker->locale);
     }
@@ -95,7 +106,18 @@ class PoeditorTest extends TestCase
     public function it_throws_an_error_if_project_id_is_empty()
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid project id');
         config()->set('poeditor-sync.project_id', '');
+
+        app(Poeditor::class)->download($this->faker->locale);
+    }
+
+    /** @test */
+    public function it_throws_an_error_if_project_id_is_null()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid project id');
+        config()->set('poeditor-sync.project_id', null);
 
         app(Poeditor::class)->download($this->faker->locale);
     }


### PR DESCRIPTION
This PR adds some checks and better error messages in the case you forgot to add the apikey or projectid to your environment file.