### PR TITLE
Unneeded file created when downloading vendor translations

### DIFF
--- a/.github/workflows/run-linting.yml
+++ b/.github/workflows/run-linting.yml
@@ -13,6 +13,6 @@ jobs:
                 uses: actions/checkout@v2
 
             -   name: Fix style
-                uses: docker://oskarstark/php-cs-fixer-ga
+                uses: docker://oskarstark/php-cs-fixer-ga:2.19.0
                 with:
                     args: --config=.php_cs --dry-run --diff-format="udiff"

--- a/src/Translations/TranslationManager.php
+++ b/src/Translations/TranslationManager.php
@@ -210,11 +210,14 @@ class TranslationManager
         foreach ($translations as $filename => $fileTranslations) {
             $array = VarExporter::export($fileTranslations);
 
-            if ($filename != 'vendor')
-                $this->filesystem->put(
-                    "{$folder}/{$filename}.php",
-                    '<?php'.PHP_EOL.PHP_EOL."return {$array};".PHP_EOL,
-                );
+            if ($filename === 'vendor') {
+                continue;
+            }
+
+            $this->filesystem->put(
+                "{$folder}/{$filename}.php",
+                '<?php'.PHP_EOL.PHP_EOL."return {$array};".PHP_EOL,
+            );
         }
     }
 

--- a/src/Translations/TranslationManager.php
+++ b/src/Translations/TranslationManager.php
@@ -210,10 +210,11 @@ class TranslationManager
         foreach ($translations as $filename => $fileTranslations) {
             $array = VarExporter::export($fileTranslations);
 
-            $this->filesystem->put(
-                "{$folder}/{$filename}.php",
-                '<?php'.PHP_EOL.PHP_EOL."return {$array};".PHP_EOL,
-            );
+            if ($filename != 'vendor')
+                $this->filesystem->put(
+                    "{$folder}/{$filename}.php",
+                    '<?php'.PHP_EOL.PHP_EOL."return {$array};".PHP_EOL,
+                );
         }
     }
 

--- a/tests/DownloadCommandTest.php
+++ b/tests/DownloadCommandTest.php
@@ -124,6 +124,9 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
+        $this->assertFalse(file_exists(resource_path('lang/en/vendor.php')));
+        $this->assertFalse(file_exists(resource_path('lang/nl/vendor.php')));
+
         $this->assertPhpTranslationFile(
             resource_path('lang/vendor/first-package/en/first-package-en-php-file.php'),
             ['foo' => 'bar']
@@ -178,6 +181,8 @@ class DownloadCommandTest extends TestCase
         ]);
 
         $this->artisan('poeditor:download')->assertExitCode(0);
+
+        $this->assertFalse(file_exists(resource_path('lang/en/vendor.php')));
 
         $this->assertPhpTranslationFile(resource_path('lang/en/php-file.php'), ['foo' => 'bar']);
         $this->assertJsonTranslationFile(resource_path('lang/en.json'), ['json-key' => 'bar foo']);
@@ -281,6 +286,7 @@ class DownloadCommandTest extends TestCase
 
         $this->assertFalse(file_exists(resource_path('lang/vendor/package-name/en/php-file.php')));
         $this->assertFalse(file_exists(resource_path('lang/vendor/package-name/en.json')));
+        $this->assertFalse(file_exists(resource_path('lang/en/vendor.php')));
 
         $this->assertTrue(file_exists(resource_path('lang/en/php-file.php')));
         $this->assertTrue(file_exists(resource_path('lang/en.json')));


### PR DESCRIPTION
When downloading vendor translations, the files inside vendor/{package} are written success, but a new file is created under the main folder under the file name vendor.php