### PR TITLE
Modernize codebase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
     ],
     "require": {
         "php": "^8.1|^8.2|^8.3",
-        "guzzlehttp/guzzle": "^6.5|^7.0",
+        "guzzlehttp/guzzle": "^7.0",
         "illuminate/filesystem": "^9.0|^10.0",
+        "illuminate/http": "^9.0|^10.0",
         "illuminate/support": "^9.0|^10.0",
         "symfony/var-exporter": "^5.0|^6.0"
     },

--- a/src/Commands/DownloadCommand.php
+++ b/src/Commands/DownloadCommand.php
@@ -19,7 +19,7 @@ class DownloadCommand extends Command
             $translations = app(Poeditor::class)->download(is_string($key) ? $key : $locale);
 
             collect($locale)->each(function ($internalLocale) use ($translations) {
-                app(TranslationManager::class)->createTranslationFiles($translations, $internalLocale);
+                app(TranslationManager::class)->createTranslationFiles(collect($translations), $internalLocale);
             });
         });
 

--- a/src/Poeditor/Poeditor.php
+++ b/src/Poeditor/Poeditor.php
@@ -3,6 +3,7 @@
 namespace NextApps\PoeditorSync\Poeditor;
 
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
 use InvalidArgumentException;
 
 class Poeditor
@@ -38,9 +39,18 @@ class Poeditor
                 'updating' => 'terms_translations',
                 'overwrite' => (int) $overwrite,
                 'fuzzy_trigger' => 1,
-            ])
-            ->json();
+            ]);
 
-        return new UploadResponse($response);
+        if ($response->json('response.status') === 'fail') {
+            if (class_exists(Sleep::class)) {
+                Sleep::for(10)->seconds();
+            } else {
+                sleep(10);
+            }
+
+            return $this->upload($language, $translations, $overwrite);
+        }
+
+        return new UploadResponse($response->json());
     }
 }

--- a/src/Poeditor/Poeditor.php
+++ b/src/Poeditor/Poeditor.php
@@ -7,25 +7,13 @@ use InvalidArgumentException;
 
 class Poeditor
 {
-    protected Client $client;
-
-    protected string $apiKey;
-
-    protected string $projectId;
-
-    public function __construct(Client $client, $apiKey, $projectId)
-    {
-        if (! is_string($apiKey) || ! $apiKey) {
-            throw new InvalidArgumentException('Invalid API key');
-        }
-
-        if (! is_string($projectId) || ! $projectId) {
-            throw new InvalidArgumentException('Invalid project id');
-        }
-
-        $this->client = $client;
-        $this->apiKey = $apiKey;
-        $this->projectId = $projectId;
+    public function __construct(
+        public Client $client,
+        public string $apiKey,
+        public string $projectId
+    ) {
+        throw_if(empty($this->apiKey), new InvalidArgumentException('Invalid API key'));
+        throw_if(empty($this->projectId), new InvalidArgumentException('Invalid project id'));
     }
 
     public function download(string $language) : array

--- a/src/Poeditor/UploadResponse.php
+++ b/src/Poeditor/UploadResponse.php
@@ -4,11 +4,9 @@ namespace NextApps\PoeditorSync\Poeditor;
 
 class UploadResponse
 {
-    protected array $content;
-
-    public function __construct(array $content)
-    {
-        $this->content = $content;
+    public function __construct(
+        protected array $content
+    ) {
     }
 
     public function getAddedTermsCount() : int

--- a/src/PoeditorSyncServiceProvider.php
+++ b/src/PoeditorSyncServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace NextApps\PoeditorSync;
 
-use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
 use NextApps\PoeditorSync\Commands\DownloadCommand;
 use NextApps\PoeditorSync\Commands\UploadCommand;
@@ -30,7 +29,6 @@ class PoeditorSyncServiceProvider extends ServiceProvider
 
         $this->app->bind(Poeditor::class, function () {
             return new Poeditor(
-                app(Client::class),
                 config('poeditor-sync.api_key'),
                 config('poeditor-sync.project_id')
             );

--- a/src/Translations/TranslationManager.php
+++ b/src/Translations/TranslationManager.php
@@ -3,7 +3,6 @@
 namespace NextApps\PoeditorSync\Translations;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\VarExporter\VarExporter;

--- a/src/Translations/TranslationManager.php
+++ b/src/Translations/TranslationManager.php
@@ -4,84 +4,66 @@ namespace NextApps\PoeditorSync\Translations;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\VarExporter\VarExporter;
 
 class TranslationManager
 {
-    protected Filesystem $filesystem;
-
-    public function __construct(Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
+    public function __construct(
+        protected Filesystem $filesystem
+    ) {
     }
 
     public function getTranslations(string $locale) : array
     {
-        $translations = array_merge(
-            $this->getPhpTranslations($this->getLangPath("/{$locale}")),
-            $this->getJsonTranslations($this->getLangPath("/{$locale}.json")),
-        );
-
-        if (config('poeditor-sync.include_vendor')) {
-            $translations += $this->getVendorTranslations($locale);
-        }
-
-        return $translations;
+        return $this->getPhpTranslations(lang_path("/{$locale}"))
+            ->merge($this->getJsonTranslations(lang_path("/{$locale}.json")))
+            ->when($this->includeVendorTranslations(), function ($translations) use ($locale) {
+                return $translations->merge($this->getVendorTranslations($locale));
+            })
+            ->jsonSerialize();
     }
 
-    public function createTranslationFiles(array $translations, string $locale) : void
+    public function createTranslationFiles(Collection $translations, string $locale) : void
     {
         $this->createEmptyLocaleFolder($locale);
 
         $this->createPhpTranslationFiles($translations, $locale);
         $this->createJsonTranslationFile($translations, $locale);
 
-        if (config('poeditor-sync.include_vendor')) {
+        if ($this->includeVendorTranslations()) {
             $this->createVendorTranslationFiles($translations, $locale);
         }
     }
 
-    protected function getVendorTranslations(string $locale) : array
+    protected function getVendorTranslations(string $locale) : Collection
     {
-        if (! $this->filesystem->exists($this->getLangPath('vendor'))) {
-            return [];
+        if (! $this->filesystem->exists(lang_path('vendor'))) {
+            return collect();
         }
 
-        $directories = collect($this->filesystem->directories($this->getLangPath('vendor')));
+        $directories = collect($this->filesystem->directories(lang_path('vendor')));
 
         $translations = $directories->mapWithKeys(function ($directory) use ($locale) {
             $phpTranslations = $this->getPhpTranslations("{$directory}/{$locale}");
             $jsonTranslations = $this->getJsonTranslations("{$directory}/{$locale}.json");
 
-            return [basename($directory) => array_merge($phpTranslations, $jsonTranslations)];
-        })->toArray();
+            return [basename($directory) => $phpTranslations->merge($jsonTranslations)];
+        });
 
-        return ['vendor' => $translations];
+        return collect(['vendor' => $translations]);
     }
 
-    protected function getPhpTranslations(string $folder) : array
+    protected function getPhpTranslations(string $folder) : Collection
     {
-        $files = collect($this->filesystem->files($folder));
-
-        $excludedFiles = collect(config('poeditor-sync.excluded_files', []))
-            ->map(function ($excludedFile) {
-                if (Str::endsWith($excludedFile, '.php')) {
-                    return $excludedFile;
-                }
-
-                return "{$excludedFile}.php";
-            });
-
-        return $files
-            ->reject(function ($file) use ($excludedFiles) {
-                return $excludedFiles->contains($file->getFilename());
-            })->mapWithKeys(function ($file) {
+        return collect($this->filesystem->files($folder))
+            ->reject(fn ($file) => $this->getExcludedFilenames()->contains($file->getFilename()))
+            ->mapWithKeys(function ($file) {
                 $filename = pathinfo($file->getRealPath(), PATHINFO_FILENAME);
 
                 return [$filename => $this->filesystem->getRequire($file->getRealPath())];
-            })
-            ->toArray();
+            });
     }
 
     protected function getJsonTranslations(string $filename) : array
@@ -93,96 +75,77 @@ class TranslationManager
         return json_decode($this->filesystem->get($filename), true);
     }
 
-    protected function createPhpTranslationFiles(array $translations, string $locale) : void
+    protected function createPhpTranslationFiles(Collection $translations, string $locale) : void
     {
-        $this->createPhpFiles($this->getLangPath($locale), $translations);
+        $this->createPhpFiles(lang_path($locale), $translations);
     }
 
-    protected function createJsonTranslationFile(array $translations, string $locale) : void
+    protected function createJsonTranslationFile(Collection $translations, string $locale) : void
     {
-        $this->createJsonFile($this->getLangPath("/{$locale}.json"), $translations);
+        $this->createJsonFile(lang_path("/{$locale}.json"), $translations);
     }
 
-    protected function createVendorTranslationFiles(array $translations, string $locale) : void
+    protected function createVendorTranslationFiles(Collection $translations, string $locale) : void
     {
-        if (! Arr::has($translations, 'vendor')) {
-            return;
-        }
+        collect($translations['vendor'] ?? [])->each(function ($packageTranslations, $package) use ($locale) {
+            $path = lang_path("/vendor/{$package}/{$locale}");
 
-        foreach ($translations['vendor'] as $package => $packageTranslations) {
-            $path = $this->getLangPath("/vendor/{$package}/{$locale}");
+            $this->filesystem->ensureDirectoryExists($path);
+            $this->filesystem->cleanDirectory($path);
 
-            if (! $this->filesystem->exists($path)) {
-                $this->filesystem->makeDirectory($path, 0755, true);
-            } else {
-                $this->filesystem->cleanDirectory($path);
-            }
-
-            $this->createPhpFiles($path, $packageTranslations);
-            $this->createJsonFile("{$path}.json", $packageTranslations);
-        }
-    }
-
-    protected function createPhpFiles(string $folder, array $translations) : void
-    {
-        $translations = Arr::where($translations, function ($translation) {
-            return is_array($translation);
+            $this->createPhpFiles($path, collect($packageTranslations));
+            $this->createJsonFile("{$path}.json", collect($packageTranslations));
         });
+    }
 
-        foreach ($translations as $filename => $fileTranslations) {
-            $array = VarExporter::export($fileTranslations);
-
+    protected function createPhpFiles(string $folder, Collection $translations) : void
+    {
+        $translations->filter(function ($translation) {
+            return is_array($translation);
+        })->each(function ($fileTranslations, $filename) use ($folder) {
             if ($filename === 'vendor') {
-                continue;
+                return;
             }
 
             $this->filesystem->put(
                 "{$folder}/{$filename}.php",
-                '<?php' . PHP_EOL . PHP_EOL . "return {$array};" . PHP_EOL,
+                '<?php' . PHP_EOL . PHP_EOL . 'return ' . VarExporter::export($fileTranslations) . ';' . PHP_EOL,
             );
-        }
+        });
     }
 
-    protected function createJsonFile(string $filename, array $translations) : void
+    protected function createJsonFile(string $filename, Collection $translations) : void
     {
-        $translations = Arr::where($translations, function ($translation) {
+        $translations->filter(function ($translation) {
             return is_string($translation);
+        })->whenNotEmpty(function ($translations) use ($filename) {
+            $this->filesystem->put($filename, json_encode($translations, JSON_PRETTY_PRINT));
         });
-
-        if (empty($translations)) {
-            return;
-        }
-
-        $this->filesystem->put($filename, json_encode($translations, JSON_PRETTY_PRINT));
     }
 
     protected function createEmptyLocaleFolder(string $locale) : void
     {
-        if (! $this->filesystem->exists($this->getLangPath())) {
-            $this->filesystem->makeDirectory($this->getLangPath());
-        }
+        $this->filesystem->ensureDirectoryExists(lang_path());
+        $this->filesystem->ensureDirectoryExists($path = lang_path($locale));
 
-        $path = $this->getLangPath($locale);
-
-        if (file_exists($path)) {
-            foreach ($this->filesystem->allFiles($path) as $file) {
-                if (! in_array($file->getFilename(), config('poeditor-sync.excluded_files', []))) {
-                    $this->filesystem->delete($file->getRealPath());
-                }
-            }
-
-            return;
-        }
-
-        $this->filesystem->makeDirectory($path);
+        collect($this->filesystem->allFiles($path))
+            ->filter(fn ($file) => $this->getExcludedFilenames()->doesntContain($file->getFilename()))
+            ->each(fn ($file) => $this->filesystem->delete($file->getRealPath()));
     }
 
-    protected function getLangPath(string $path = null) : string
+    protected function getExcludedFilenames() : Collection
     {
-        if (function_exists('lang_path')) {
-            return lang_path($path);
-        }
+        return collect(config('poeditor-sync.excluded_files', []))->map(function ($excludedFile) {
+            if (Str::endsWith($excludedFile, '.php')) {
+                return $excludedFile;
+            }
 
-        return resource_path("lang/{$path}");
+            return "{$excludedFile}.php";
+        });
+    }
+
+    protected function includeVendorTranslations() : bool
+    {
+        return config('poeditor-sync.include_vendor');
     }
 }

--- a/tests/DownloadCommandTest.php
+++ b/tests/DownloadCommandTest.php
@@ -12,8 +12,8 @@ class DownloadCommandTest extends TestCase
     {
         parent::setUp();
 
-        app(Filesystem::class)->cleanDirectory($this->getLangPath());
-        app(Filesystem::class)->makeDirectory($this->getLangPath('en'));
+        app(Filesystem::class)->cleanDirectory(lang_path());
+        app(Filesystem::class)->makeDirectory(lang_path('en'));
     }
 
     /** @test */
@@ -41,10 +41,10 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertPhpTranslationFile($this->getLangPath('en/first-en-php-file.php'), ['foo' => 'bar']);
-        $this->assertPhpTranslationFile($this->getLangPath('en/second-en-php-file.php'), ['foo_bar' => 'bar foo']);
-        $this->assertPhpTranslationFile($this->getLangPath('nl/first-nl-php-file.php'), ['bar_foo' => 'foo bar']);
-        $this->assertPhpTranslationFile($this->getLangPath('nl/second-nl-php-file.php'), ['bar' => 'foo']);
+        $this->assertPhpTranslationFile(lang_path('en/first-en-php-file.php'), ['foo' => 'bar']);
+        $this->assertPhpTranslationFile(lang_path('en/second-en-php-file.php'), ['foo_bar' => 'bar foo']);
+        $this->assertPhpTranslationFile(lang_path('nl/first-nl-php-file.php'), ['bar_foo' => 'foo bar']);
+        $this->assertPhpTranslationFile(lang_path('nl/second-nl-php-file.php'), ['bar' => 'foo']);
     }
 
     /** @test */
@@ -64,11 +64,11 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertJsonTranslationFile($this->getLangPath('en.json'), [
+        $this->assertJsonTranslationFile(lang_path('en.json'), [
             'first-en-json-key' => 'bar',
             'second-en-json-key' => 'bar foo',
         ]);
-        $this->assertJsonTranslationFile($this->getLangPath('nl.json'), [
+        $this->assertJsonTranslationFile(lang_path('nl.json'), [
             'first-nl-json-key' => 'foo bar',
             'second-nl-json-key' => 'foo',
         ]);
@@ -119,39 +119,39 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertFalse(file_exists($this->getLangPath('en/vendor.php')));
-        $this->assertFalse(file_exists($this->getLangPath('nl/vendor.php')));
+        $this->assertFalse(file_exists(lang_path('en/vendor.php')));
+        $this->assertFalse(file_exists(lang_path('nl/vendor.php')));
 
         $this->assertPhpTranslationFile(
-            $this->getLangPath('vendor/first-package/en/first-package-en-php-file.php'),
+            lang_path('vendor/first-package/en/first-package-en-php-file.php'),
             ['foo' => 'bar']
         );
-        $this->assertJsonTranslationFile($this->getLangPath('vendor/first-package/en.json'), [
+        $this->assertJsonTranslationFile(lang_path('vendor/first-package/en.json'), [
             'first-package-first-en-json-key' => 'bar foo',
             'first-package-second-en-json-key' => 'foo bar',
         ]);
         $this->assertPhpTranslationFile(
-            $this->getLangPath('vendor/second-package/en/second-package-en-php-file.php'),
+            lang_path('vendor/second-package/en/second-package-en-php-file.php'),
             ['bar' => 'foo']
         );
-        $this->assertJsonTranslationFile($this->getLangPath('vendor/second-package/en.json'), [
+        $this->assertJsonTranslationFile(lang_path('vendor/second-package/en.json'), [
             'second-package-first-en-json-key' => 'bar foo bar',
             'second-package-second-en-json-key' => 'foo bar foo',
         ]);
 
         $this->assertPhpTranslationFile(
-            $this->getLangPath('vendor/first-package/nl/first-package-nl-php-file.php'),
+            lang_path('vendor/first-package/nl/first-package-nl-php-file.php'),
             ['bar' => 'foo']
         );
-        $this->assertJsonTranslationFile($this->getLangPath('vendor/first-package/nl.json'), [
+        $this->assertJsonTranslationFile(lang_path('vendor/first-package/nl.json'), [
             'first-package-first-nl-json-key' => 'foo bar',
             'first-package-second-nl-json-key' => 'bar foo',
         ]);
         $this->assertPhpTranslationFile(
-            $this->getLangPath('vendor/second-package/nl/second-package-nl-php-file.php'),
+            lang_path('vendor/second-package/nl/second-package-nl-php-file.php'),
             ['foo' => 'bar']
         );
-        $this->assertJsonTranslationFile($this->getLangPath('vendor/second-package/nl.json'), [
+        $this->assertJsonTranslationFile(lang_path('vendor/second-package/nl.json'), [
             'second-package-first-nl-json-key' => 'foo bar foo',
             'second-package-second-nl-json-key' => 'bar foo bar',
         ]);
@@ -177,18 +177,18 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertFalse(file_exists($this->getLangPath('en/vendor.php')));
+        $this->assertFalse(file_exists(lang_path('en/vendor.php')));
 
-        $this->assertPhpTranslationFile($this->getLangPath('en/php-file.php'), ['foo' => 'bar']);
-        $this->assertJsonTranslationFile($this->getLangPath('en.json'), ['json-key' => 'bar foo']);
-        $this->assertPhpTranslationFile($this->getLangPath('vendor/package-name/en/package-php-file.php'), ['bar' => 'foo']);
-        $this->assertJsonTranslationFile($this->getLangPath('vendor/package-name/en.json'), ['package-json-key' => 'foo bar foo']);
+        $this->assertPhpTranslationFile(lang_path('en/php-file.php'), ['foo' => 'bar']);
+        $this->assertJsonTranslationFile(lang_path('en.json'), ['json-key' => 'bar foo']);
+        $this->assertPhpTranslationFile(lang_path('vendor/package-name/en/package-php-file.php'), ['bar' => 'foo']);
+        $this->assertJsonTranslationFile(lang_path('vendor/package-name/en.json'), ['package-json-key' => 'foo bar foo']);
     }
 
     /** @test */
     public function it_removes_old_php_translations_of_locale()
     {
-        file_put_contents($this->getLangPath('en/old-php-file.php'), ['foo' => 'bar']);
+        file_put_contents(lang_path('en/old-php-file.php'), ['foo' => 'bar']);
 
         $this->mockPoeditorDownload('en', [
             'new-php-file' => [
@@ -198,15 +198,15 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertFalse(file_exists($this->getLangPath('en/old-php-file.php')));
-        $this->assertTrue(file_exists($this->getLangPath('en/new-php-file.php')));
+        $this->assertFalse(file_exists(lang_path('en/old-php-file.php')));
+        $this->assertTrue(file_exists(lang_path('en/new-php-file.php')));
     }
 
     /** @test */
     public function it_does_not_remove_php_translations_of_locale_if_php_translation_is_excluded_in_config()
     {
-        file_put_contents($this->getLangPath('en/excluded-php-file.php'), ['foo' => 'bar']);
-        file_put_contents($this->getLangPath('en/not-excluded-php-file.php'), ['foo' => 'bar']);
+        file_put_contents(lang_path('en/excluded-php-file.php'), ['foo' => 'bar']);
+        file_put_contents(lang_path('en/not-excluded-php-file.php'), ['foo' => 'bar']);
 
         config()->set('poeditor-sync.excluded_files', ['excluded-php-file.php']);
 
@@ -218,29 +218,29 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertTrue(file_exists($this->getLangPath('en/excluded-php-file.php')));
-        $this->assertFalse(file_exists($this->getLangPath('en/not-excluded-php-file.php')));
-        $this->assertTrue(file_exists($this->getLangPath('en/some-php-file.php')));
+        $this->assertTrue(file_exists(lang_path('en/excluded-php-file.php')));
+        $this->assertFalse(file_exists(lang_path('en/not-excluded-php-file.php')));
+        $this->assertTrue(file_exists(lang_path('en/some-php-file.php')));
     }
 
     /** @test */
     public function it_overrides_old_json_translation_of_locale()
     {
-        file_put_contents($this->getLangPath('en.json'), json_encode(['foo' => 'bar'], JSON_PRETTY_PRINT));
+        file_put_contents(lang_path('en.json'), json_encode(['foo' => 'bar'], JSON_PRETTY_PRINT));
 
         $this->mockPoeditorDownload('en', ['bar' => 'foo']);
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertJsonTranslationFile($this->getLangPath('en.json'), ['bar' => 'foo']);
+        $this->assertJsonTranslationFile(lang_path('en.json'), ['bar' => 'foo']);
     }
 
     /** @test */
     public function it_removes_old_php_vendor_translations_of_locale()
     {
-        app(Filesystem::class)->makeDirectory($this->getLangPath('vendor/package-name/en/'), 0755, true);
+        app(Filesystem::class)->makeDirectory(lang_path('vendor/package-name/en/'), 0755, true);
 
-        file_put_contents($this->getLangPath('vendor/package-name/en/old-php-file.php'), ['foo' => 'bar']);
+        file_put_contents(lang_path('vendor/package-name/en/old-php-file.php'), ['foo' => 'bar']);
 
         $this->mockPoeditorDownload('en', [
             'vendor' => [
@@ -254,16 +254,16 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertFalse(file_exists($this->getLangPath('vendor/package-name/en/old-php-file.php')));
-        $this->assertTrue(file_exists($this->getLangPath('vendor/package-name/en/new-php-file.php')));
+        $this->assertFalse(file_exists(lang_path('vendor/package-name/en/old-php-file.php')));
+        $this->assertTrue(file_exists(lang_path('vendor/package-name/en/new-php-file.php')));
     }
 
     /** @test */
     public function it_overrides_old_json_vendor_translations_of_locale()
     {
-        app(Filesystem::class)->makeDirectory($this->getLangPath('vendor/package-name'), 0755, true);
+        app(Filesystem::class)->makeDirectory(lang_path('vendor/package-name'), 0755, true);
 
-        file_put_contents($this->getLangPath('vendor/package-name/en.json'), json_encode(['foo' => 'bar'], JSON_PRETTY_PRINT));
+        file_put_contents(lang_path('vendor/package-name/en.json'), json_encode(['foo' => 'bar'], JSON_PRETTY_PRINT));
 
         $this->mockPoeditorDownload('en', [
             'vendor' => [
@@ -275,7 +275,7 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertJsonTranslationFile($this->getLangPath('vendor/package-name/en.json'), ['bar' => 'foo']);
+        $this->assertJsonTranslationFile(lang_path('vendor/package-name/en.json'), ['bar' => 'foo']);
     }
 
     /** @test */
@@ -300,12 +300,12 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertFalse(file_exists($this->getLangPath('vendor/package-name/en/php-file.php')));
-        $this->assertFalse(file_exists($this->getLangPath('vendor/package-name/en.json')));
-        $this->assertFalse(file_exists($this->getLangPath('en/vendor.php')));
+        $this->assertFalse(file_exists(lang_path('vendor/package-name/en/php-file.php')));
+        $this->assertFalse(file_exists(lang_path('vendor/package-name/en.json')));
+        $this->assertFalse(file_exists(lang_path('en/vendor.php')));
 
-        $this->assertTrue(file_exists($this->getLangPath('en/php-file.php')));
-        $this->assertTrue(file_exists($this->getLangPath('en.json')));
+        $this->assertTrue(file_exists(lang_path('en/php-file.php')));
+        $this->assertTrue(file_exists(lang_path('en.json')));
     }
 
     /** @test */
@@ -319,8 +319,8 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertTrue(file_exists($this->getLangPath('en/php-file.php')));
-        $this->assertFalse(file_exists($this->getLangPath('en.json')));
+        $this->assertTrue(file_exists(lang_path('en/php-file.php')));
+        $this->assertFalse(file_exists(lang_path('en.json')));
     }
 
     /** @test */
@@ -344,10 +344,10 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertPhpTranslationFile($this->getLangPath('en/en-php-file.php'), ['foo' => 'bar']);
-        $this->assertJsonTranslationFile($this->getLangPath('en.json'), ['foo bar' => 'bar foo']);
-        $this->assertPhpTranslationFile($this->getLangPath('nl/nl-php-file.php'), ['bar' => 'foo']);
-        $this->assertJsonTranslationFile($this->getLangPath('nl.json'), ['bar foo' => 'foo bar']);
+        $this->assertPhpTranslationFile(lang_path('en/en-php-file.php'), ['foo' => 'bar']);
+        $this->assertJsonTranslationFile(lang_path('en.json'), ['foo bar' => 'bar foo']);
+        $this->assertPhpTranslationFile(lang_path('nl/nl-php-file.php'), ['bar' => 'foo']);
+        $this->assertJsonTranslationFile(lang_path('nl.json'), ['bar foo' => 'foo bar']);
     }
 
     /** @test */
@@ -371,12 +371,12 @@ class DownloadCommandTest extends TestCase
 
         $this->artisan('poeditor:download')->assertExitCode(0);
 
-        $this->assertPhpTranslationFile($this->getLangPath('en_GB/en-php-file.php'), ['foo' => 'bar']);
-        $this->assertJsonTranslationFile($this->getLangPath('en_GB.json'), ['foo bar' => 'bar foo']);
-        $this->assertPhpTranslationFile($this->getLangPath('nl_BE/nl-php-file.php'), ['bar' => 'foo']);
-        $this->assertJsonTranslationFile($this->getLangPath('nl_BE.json'), ['bar foo' => 'foo bar']);
-        $this->assertPhpTranslationFile($this->getLangPath('nl_NL/nl-php-file.php'), ['bar' => 'foo']);
-        $this->assertJsonTranslationFile($this->getLangPath('nl_NL.json'), ['bar foo' => 'foo bar']);
+        $this->assertPhpTranslationFile(lang_path('en_GB/en-php-file.php'), ['foo' => 'bar']);
+        $this->assertJsonTranslationFile(lang_path('en_GB.json'), ['foo bar' => 'bar foo']);
+        $this->assertPhpTranslationFile(lang_path('nl_BE/nl-php-file.php'), ['bar' => 'foo']);
+        $this->assertJsonTranslationFile(lang_path('nl_BE.json'), ['bar foo' => 'foo bar']);
+        $this->assertPhpTranslationFile(lang_path('nl_NL/nl-php-file.php'), ['bar' => 'foo']);
+        $this->assertJsonTranslationFile(lang_path('nl_NL.json'), ['bar foo' => 'foo bar']);
     }
 
     /**

--- a/tests/PoeditorTest.php
+++ b/tests/PoeditorTest.php
@@ -82,31 +82,11 @@ class PoeditorTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_error_if_api_key_is_null()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid API key');
-        config()->set('poeditor-sync.api_key', null);
-
-        app(Poeditor::class)->download($this->faker->locale());
-    }
-
-    /** @test */
     public function it_throws_an_error_if_project_id_is_empty()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid project id');
         config()->set('poeditor-sync.project_id', '');
-
-        app(Poeditor::class)->download($this->faker->locale());
-    }
-
-    /** @test */
-    public function it_throws_an_error_if_project_id_is_null()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid project id');
-        config()->set('poeditor-sync.project_id', null);
 
         app(Poeditor::class)->download($this->faker->locale());
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,13 +27,4 @@ class TestCase extends BaseTestCase
             PoeditorSyncServiceProvider::class,
         ];
     }
-
-    protected function getLangPath(string $path = null) : string
-    {
-        if (function_exists('lang_path')) {
-            return lang_path($path);
-        }
-
-        return resource_path("lang/{$path}");
-    }
 }

--- a/tests/UploadCommandTest.php
+++ b/tests/UploadCommandTest.php
@@ -13,17 +13,17 @@ class UploadCommandTest extends TestCase
     {
         parent::setUp();
 
-        app(Filesystem::class)->cleanDirectory($this->getLangPath());
-        app(Filesystem::class)->makeDirectory($this->getLangPath('en'));
+        app(Filesystem::class)->cleanDirectory(lang_path());
+        app(Filesystem::class)->makeDirectory(lang_path('en'));
     }
 
     /** @test */
     public function it_uploads_php_translations_of_default_locale()
     {
-        $this->createPhpTranslationFile($this->getLangPath('en/first-en-php-file.php'), ['foo' => 'bar']);
-        $this->createPhpTranslationFile($this->getLangPath('en/second-en-php-file.php'), ['bar' => 'foo']);
+        $this->createPhpTranslationFile(lang_path('en/first-en-php-file.php'), ['foo' => 'bar']);
+        $this->createPhpTranslationFile(lang_path('en/second-en-php-file.php'), ['bar' => 'foo']);
 
-        $this->createPhpTranslationFile($this->getLangPath('nl/nl-php-file.php'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('nl/nl-php-file.php'), ['foo_bar' => 'bar foo']);
 
         $this->mockPoeditorUpload('en', [
             'first-en-php-file' => [
@@ -57,9 +57,9 @@ class UploadCommandTest extends TestCase
     /** @test */
     public function it_uploads_json_translations_of_default_locale()
     {
-        $this->createJsonTranslationFile($this->getLangPath('en.json'), ['foo' => 'bar', 'foo_bar' => 'bar foo']);
+        $this->createJsonTranslationFile(lang_path('en.json'), ['foo' => 'bar', 'foo_bar' => 'bar foo']);
 
-        $this->createJsonTranslationFile($this->getLangPath('nl.json'), ['bar' => 'foo']);
+        $this->createJsonTranslationFile(lang_path('nl.json'), ['bar' => 'foo']);
 
         $this->mockPoeditorUpload('en', [
             'foo' => 'bar',
@@ -72,11 +72,11 @@ class UploadCommandTest extends TestCase
     /** @test */
     public function it_uploads_vendor_translations()
     {
-        $this->createPhpTranslationFile($this->getLangPath('vendor/first-package/en/first-package-php-file.php'), ['bar_foo_bar' => 'foo bar foo']);
-        $this->createJsonTranslationFile($this->getLangPath('vendor/first-package/en.json'), ['bar_foo' => 'foo bar']);
+        $this->createPhpTranslationFile(lang_path('vendor/first-package/en/first-package-php-file.php'), ['bar_foo_bar' => 'foo bar foo']);
+        $this->createJsonTranslationFile(lang_path('vendor/first-package/en.json'), ['bar_foo' => 'foo bar']);
 
-        $this->createPhpTranslationFile($this->getLangPath('vendor/second-package/en/second-package-php-file.php'), ['foo_bar_foo' => 'bar foo bar']);
-        $this->createJsonTranslationFile($this->getLangPath('vendor/second-package/en.json'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('vendor/second-package/en/second-package-php-file.php'), ['foo_bar_foo' => 'bar foo bar']);
+        $this->createJsonTranslationFile(lang_path('vendor/second-package/en.json'), ['foo_bar' => 'bar foo']);
 
         $this->mockPoeditorUpload('en', [
             'vendor' => [
@@ -101,10 +101,10 @@ class UploadCommandTest extends TestCase
     /** @test */
     public function it_uploads_php_and_json_and_vendor_translations()
     {
-        $this->createPhpTranslationFile($this->getLangPath('en/php-file.php'), ['bar' => 'foo']);
-        $this->createJsonTranslationFile($this->getLangPath('en.json'), ['foo_bar' => 'bar foo']);
-        $this->createPhpTranslationFile($this->getLangPath('vendor/package-name/en/package-php-file.php'), ['bar_foo_bar' => 'foo bar foo']);
-        $this->createJsonTranslationFile($this->getLangPath('vendor/package-name/en.json'), ['bar_foo' => 'foo bar']);
+        $this->createPhpTranslationFile(lang_path('en/php-file.php'), ['bar' => 'foo']);
+        $this->createJsonTranslationFile(lang_path('en.json'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('vendor/package-name/en/package-php-file.php'), ['bar_foo_bar' => 'foo bar foo']);
+        $this->createJsonTranslationFile(lang_path('vendor/package-name/en.json'), ['bar_foo' => 'foo bar']);
 
         $this->mockPoeditorUpload('en', [
             'php-file' => [
@@ -127,11 +127,11 @@ class UploadCommandTest extends TestCase
     /** @test */
     public function it_uploads_translations_of_provided_locale()
     {
-        $this->createPhpTranslationFile($this->getLangPath('en/en-php-file.php'), ['bar' => 'foo']);
-        $this->createJsonTranslationFile($this->getLangPath('en.json'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('en/en-php-file.php'), ['bar' => 'foo']);
+        $this->createJsonTranslationFile(lang_path('en.json'), ['foo_bar' => 'bar foo']);
 
-        $this->createPhpTranslationFile($this->getLangPath('nl/nl-php-file.php'), ['foo' => 'bar']);
-        $this->createJsonTranslationFile($this->getLangPath('nl.json'), ['bar_foo' => 'foo bar']);
+        $this->createPhpTranslationFile(lang_path('nl/nl-php-file.php'), ['foo' => 'bar']);
+        $this->createJsonTranslationFile(lang_path('nl.json'), ['bar_foo' => 'foo bar']);
 
         $this->mockPoeditorUpload('nl', [
             'nl-php-file' => [
@@ -173,11 +173,11 @@ class UploadCommandTest extends TestCase
     {
         config()->set('poeditor-sync.include_vendor', false);
 
-        $this->createPhpTranslationFile($this->getLangPath('en/php-file.php'), ['bar' => 'foo']);
-        $this->createJsonTranslationFile($this->getLangPath('en.json'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('en/php-file.php'), ['bar' => 'foo']);
+        $this->createJsonTranslationFile(lang_path('en.json'), ['foo_bar' => 'bar foo']);
 
-        $this->createPhpTranslationFile($this->getLangPath('vendor/package-name/en/php-file.php'), ['bar_foo_bar' => 'foo bar foo']);
-        $this->createJsonTranslationFile($this->getLangPath('vendor/package-name/en.json'), ['bar_foo' => 'foo bar']);
+        $this->createPhpTranslationFile(lang_path('vendor/package-name/en/php-file.php'), ['bar_foo_bar' => 'foo bar foo']);
+        $this->createJsonTranslationFile(lang_path('vendor/package-name/en.json'), ['bar_foo' => 'foo bar']);
 
         $this->mockPoeditorUpload('en', [
             'php-file' => [
@@ -197,11 +197,11 @@ class UploadCommandTest extends TestCase
             'validation.php',
         ]);
 
-        $this->createPhpTranslationFile($this->getLangPath('en/php-file.php'), ['bar' => 'foo']);
-        $this->createJsonTranslationFile($this->getLangPath('en.json'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('en/php-file.php'), ['bar' => 'foo']);
+        $this->createJsonTranslationFile(lang_path('en.json'), ['foo_bar' => 'bar foo']);
 
-        $this->createPhpTranslationFile($this->getLangPath('en/auth.php'), ['bar' => 'foo']);
-        $this->createPhpTranslationFile($this->getLangPath('en/validation.php'), ['foobar' => 'barfoo']);
+        $this->createPhpTranslationFile(lang_path('en/auth.php'), ['bar' => 'foo']);
+        $this->createPhpTranslationFile(lang_path('en/validation.php'), ['foobar' => 'barfoo']);
 
         $this->mockPoeditorUpload('en', [
             'php-file' => [
@@ -218,8 +218,8 @@ class UploadCommandTest extends TestCase
     {
         config()->set('poeditor-sync.locales', ['en-gb' => 'en']);
 
-        $this->createPhpTranslationFile($this->getLangPath('en/en-php-file.php'), ['bar' => 'foo']);
-        $this->createJsonTranslationFile($this->getLangPath('en.json'), ['foo_bar' => 'bar foo']);
+        $this->createPhpTranslationFile(lang_path('en/en-php-file.php'), ['bar' => 'foo']);
+        $this->createJsonTranslationFile(lang_path('en.json'), ['foo_bar' => 'bar foo']);
 
         $this->mockPoeditorUpload('en-gb', [
             'en-php-file' => [
@@ -236,11 +236,11 @@ class UploadCommandTest extends TestCase
     {
         config()->set('poeditor-sync.locales', ['nl' => ['nl_BE', 'nl_NL']]);
 
-        $this->createPhpTranslationFile($this->getLangPath('nl_NL/nl-php-file.php'), ['bar' => 'foo NL']);
-        $this->createJsonTranslationFile($this->getLangPath('nl_NL.json'), ['foo_bar' => 'bar foo NL']);
+        $this->createPhpTranslationFile(lang_path('nl_NL/nl-php-file.php'), ['bar' => 'foo NL']);
+        $this->createJsonTranslationFile(lang_path('nl_NL.json'), ['foo_bar' => 'bar foo NL']);
 
-        $this->createPhpTranslationFile($this->getLangPath('nl_BE/nl-php-file.php'), ['bar' => 'foo BE']);
-        $this->createJsonTranslationFile($this->getLangPath('nl_BE.json'), ['foo_bar' => 'bar foo BE']);
+        $this->createPhpTranslationFile(lang_path('nl_BE/nl-php-file.php'), ['bar' => 'foo BE']);
+        $this->createJsonTranslationFile(lang_path('nl_BE.json'), ['foo_bar' => 'bar foo BE']);
 
         $this->mockPoeditorUpload('nl', [
             'nl-php-file' => [


### PR DESCRIPTION
- remove code that was specific for old laravel versions
- use collections instead of arrays in translationmanager
- switch to laravel's HTTP client instead of a guzzle client
- update poeditor class to ensure it can handle a rate limiting error when uploading translations